### PR TITLE
Removed groupBy and fixed relation error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "illuminate/database": "5.6.*"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.6.0"
+        "orchestra/testbench": "~3.6.0",
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Traits/EloquentJoinTrait.php
+++ b/src/Traits/EloquentJoinTrait.php
@@ -142,7 +142,7 @@ trait EloquentJoinTrait
 
         if (! $this->selected  &&  count($relations) > 1) {
             $this->selected = true;
-            $builder->select($baseTable . '.*')->groupBy($baseTable . '.' . $baseModel->primaryKey);
+            $builder->select($baseTable . '.*');
         }
 
         return $currentTable . '.' . $column;

--- a/src/Traits/EloquentJoinTrait.php
+++ b/src/Traits/EloquentJoinTrait.php
@@ -83,21 +83,14 @@ trait EloquentJoinTrait
     private function performJoin($builder, $relations)
     {
         $relations = explode('.', $relations);
-
-        $column = end($relations);
+        $column = array_pop($relations);
         $baseTable = $this->getTable();
-        $baseModel = $this;
 
         $currentModel = $this;
         $currentPrimaryKey = $this->getKeyName();
         $currentTable = $this->getTable();
 
         foreach ($relations as $relation) {
-            if ($relation == $column) {
-                //last item in $relations argument is sort|where column
-                continue;
-            }
-
             $relatedRelation = $currentModel->$relation();
             $relatedModel = $relatedRelation->getRelated();
             $relatedPrimaryKey = $relatedModel->getKeyName();
@@ -140,7 +133,7 @@ trait EloquentJoinTrait
             $this->joinedTables[$relation] = $relatedTableAlias;
         }
 
-        if (! $this->selected  &&  count($relations) > 1) {
+        if (!$this->selected && !empty($relations)) {
             $this->selected = true;
             $builder->select($baseTable . '.*');
         }

--- a/tests/Tests/HasOneLeftJoinTest.php
+++ b/tests/Tests/HasOneLeftJoinTest.php
@@ -21,7 +21,7 @@ class HasOneLeftJoinTest extends TestCase
         Location::create(['address' => 'test2','seller_id' => $seller->id, 'is_primary' => 1]);
 
         $items = Seller::orderByJoin('locationPrimary.address')->get();
-        $this->assertEquals(1, $items->count());
+        $this->assertEquals(2, $items->count());
         $this->assertEquals(1, Seller::count());
     }
 

--- a/tests/Tests/OrderByJoinTest.php
+++ b/tests/Tests/OrderByJoinTest.php
@@ -71,13 +71,13 @@ class OrderByJoinTest extends TestCase
     public function testOrderByJoinJoinThirdRelationHasOne()
     {
         $items = OrderItem::orderByJoin('order.seller.location.address')->get();
-        $this->checkOrder($items, [1, 2, 3], 3);
+        $this->checkOrder($items, [1, 2, 3, 3], 4);
 
         $items = OrderItem::orderByJoin('order.seller.location.address', 'desc')->get();
-        $this->checkOrder($items, [3, 2 , 1], 3);
+        $this->checkOrder($items, [3, 3, 2, 1], 4);
 
         Location::find(2)->update(['address' => 9]);
         $items = OrderItem::orderByJoin('order.seller.location.address', 'desc')->get();
-        $this->checkOrder($items, [2, 3 , 1], 3);
+        $this->checkOrder($items, [2, 3, 3, 1], 4);
     }
 }

--- a/tests/Tests/SoftDeleteTest.php
+++ b/tests/Tests/SoftDeleteTest.php
@@ -38,28 +38,28 @@ class SoftDeleteTest extends TestCase
     public function testRelatedWithoutTrashedDefault()
     {
         OrderItem::orderByJoin('order.number')->get();
-        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" and "orders"."deleted_at" is null where "order_items"."deleted_at" is null group by "order_items"."id" order by "orders"."number" asc/';
+        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" and "orders"."deleted_at" is null where "order_items"."deleted_at" is null order by "orders"."number" asc/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 
     public function testRelatedWithoutTrashed()
     {
         OrderItem::orderByJoin('order.number')->withoutTrashed()->get();
-        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" and "orders"."deleted_at" is null where "order_items"."deleted_at" is null group by "order_items"."id" order by "orders"."number" asc/';
+        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" and "orders"."deleted_at" is null where "order_items"."deleted_at" is null order by "orders"."number" asc/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 
     public function testRelatedOnlyTrashed()
     {
         OrderItem::orderByJoin('order.number')->onlyTrashed()->get();
-        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" and "orders"."deleted_at" is null where "order_items"."deleted_at" is not null group by "order_items"."id" order by "orders"."number" asc/';
+        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" and "orders"."deleted_at" is null where "order_items"."deleted_at" is not null order by "orders"."number" asc/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 
     public function testRelatedWithTrashed()
     {
         OrderItem::orderByJoin('order.number')->withTrashed()->get();
-        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" and "orders"."deleted_at" is null group by "order_items"."id" order by "orders"."number" asc/';
+        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" and "orders"."deleted_at" is null order by "orders"."number" asc/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 
@@ -67,14 +67,14 @@ class SoftDeleteTest extends TestCase
     public function testRelatedWithTrashedOnRelation()
     {
         OrderItem::orderByJoin('orderWithTrashed.number')->get();
-        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" where "order_items"."deleted_at" is null group by "order_items"."id" order by "orders"."number" asc/';
+        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" where "order_items"."deleted_at" is null order by "orders"."number" asc/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 
     public function testRelatedOnlyTrashedOnRelation()
     {
         OrderItem::orderByJoin('orderOnlyTrashed.number')->get();
-        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" and "orders"."deleted_at" is not null where "order_items"."deleted_at" is null group by "order_items"."id" order by "orders"."number" asc/';
+        $queryTest = '/select "order_items".* from "order_items" left join "orders" on "orders"."id" = "order_items"."order_id" and "orders"."deleted_at" is not null where "order_items"."deleted_at" is null order by "orders"."number" asc/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 }

--- a/tests/Tests/WhereJoinTest.php
+++ b/tests/Tests/WhereJoinTest.php
@@ -21,7 +21,7 @@ class WhereJoinTest extends TestCase
     {
         Seller::whereJoin('city.name', '=', 'test')->get();
 
-        $queryTest = '/select "sellers".* from "sellers" left join "cities" on "cities"."id" = "sellers"."city_id" and "cities"."deleted_at" is null where "cities"."name" = \? group by "sellers"."id"/';
+        $queryTest = '/select "sellers".* from "sellers" left join "cities" on "cities"."id" = "sellers"."city_id" and "cities"."deleted_at" is null where "cities"."name" = \?/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 
@@ -29,7 +29,7 @@ class WhereJoinTest extends TestCase
     {
         Seller::whereJoin('locationPrimary.address', '=', 'test')->get();
 
-        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? and "locations"."deleted_at" is null where "locations"."address" = \? group by "sellers"."id"/';
+        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? and "locations"."deleted_at" is null where "locations"."address" = \?/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 
@@ -37,7 +37,7 @@ class WhereJoinTest extends TestCase
     {
         Seller::whereJoin('city.state.name', '=', 'test')->get();
 
-        $queryTest = '/select "sellers".* from "sellers" left join "cities" on "cities"."id" = "sellers"."city_id" and "cities"."deleted_at" is null left join "states" on "states"."id" = "cities"."state_id" and "states"."deleted_at" is null where "states"."name" = \? group by "sellers"."id"/';
+        $queryTest = '/select "sellers".* from "sellers" left join "cities" on "cities"."id" = "sellers"."city_id" and "cities"."deleted_at" is null left join "states" on "states"."id" = "cities"."state_id" and "states"."deleted_at" is null where "states"."name" = \?/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 
@@ -45,7 +45,7 @@ class WhereJoinTest extends TestCase
     {
         Seller::whereJoin('city.zipCodePrimary.name', '=', 'test')->get();
 
-        $queryTest = '/select "sellers".* from "sellers" left join "cities" on "cities"."id" = "sellers"."city_id" and "cities"."deleted_at" is null left join "zip_codes" on "zip_codes"."city_id" = "cities"."id" and "zip_codes"."is_primary" = \? and "zip_codes"."deleted_at" is null where "zip_codes"."name" = \? group by "sellers"."id"/';
+        $queryTest = '/select "sellers".* from "sellers" left join "cities" on "cities"."id" = "sellers"."city_id" and "cities"."deleted_at" is null left join "zip_codes" on "zip_codes"."city_id" = "cities"."id" and "zip_codes"."is_primary" = \? and "zip_codes"."deleted_at" is null where "zip_codes"."name" = \?/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 
@@ -53,7 +53,7 @@ class WhereJoinTest extends TestCase
     {
         Seller::whereJoin('locationPrimary.locationAddressPrimary.name', '=', 'test')->get();
 
-        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? and "locations"."deleted_at" is null left join "location_addresses" on "location_addresses"."location_id" = "locations"."id" and "location_addresses"."is_primary" = \? and "location_addresses"."deleted_at" is null where "location_addresses"."name" = \? group by "sellers"."id"/';
+        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? and "locations"."deleted_at" is null left join "location_addresses" on "location_addresses"."location_id" = "locations"."id" and "location_addresses"."is_primary" = \? and "location_addresses"."deleted_at" is null where "location_addresses"."name" = \?/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 
@@ -61,7 +61,7 @@ class WhereJoinTest extends TestCase
     {
         Seller::whereJoin('locationPrimary.city.name', '=', 'test')->get();
 
-        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? and "locations"."deleted_at" is null left join "cities" on "cities"."id" = "locations"."city_id" and "cities"."deleted_at" is null where "cities"."name" = \? group by "sellers"."id"/';
+        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? and "locations"."deleted_at" is null left join "cities" on "cities"."id" = "locations"."city_id" and "cities"."deleted_at" is null where "cities"."name" = \?/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 

--- a/tests/Tests/WhereOnRelationTest.php
+++ b/tests/Tests/WhereOnRelationTest.php
@@ -11,22 +11,22 @@ class WhereOnRelationTest extends TestCase
     {
         //location have two where  ['is_primary => 0', 'is_secondary' => 0]
         $items = Seller::orderByJoin('location.id', 'desc')->get();
-        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? and "locations"."is_secondary" = \? and "locations"."deleted_at" is null group by "sellers"."id" order by "locations"."id" desc/';
+        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? and "locations"."is_secondary" = \? and "locations"."deleted_at" is null order by "locations"."id" desc/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
 
         //locationPrimary have one where ['is_primary => 1']
         $items = Seller::orderByJoin('locationPrimary.id', 'desc')->get();
-        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? and "locations"."deleted_at" is null group by "sellers"."id" order by "locations"."id" desc/';
+        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? and "locations"."deleted_at" is null order by "locations"."id" desc/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
 
         //locationPrimary have one where ['is_secondary => 1']
         $items = Seller::orderByJoin('locationSecondary.id', 'desc')->get();
-        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_secondary" = \? and "locations"."deleted_at" is null group by "sellers"."id" order by "locations"."id" desc/';
+        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_secondary" = \? and "locations"."deleted_at" is null order by "locations"."id" desc/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
 
         //locationPrimary have one where ['is_primary => 1'] and one orWhere ['is_secondary => 1']
         $items = Seller::orderByJoin('locationPrimaryOrSecondary.id', 'desc')->get();
-        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? or "locations"."is_secondary" = \? and "locations"."deleted_at" is null group by "sellers"."id" order by "locations"."id" desc/';
+        $queryTest = '/select "sellers".* from "sellers" left join "locations" on "locations"."seller_id" = "sellers"."id" and "locations"."is_primary" = \? or "locations"."is_secondary" = \? and "locations"."deleted_at" is null order by "locations"."id" desc/';
         $this->assertRegExp($queryTest, $this->fetchQuery());
     }
 


### PR DESCRIPTION
1. Removed groupBy and updated tests. In #5 you decide not to use groupBy. This can lead to duplicate results.
2. Fixed error when relation has same name with the column. In this case relation was skipped.