### PR TITLE
check if relationClauses is set. does not seem set at all times in la…

### DIFF
--- a/src/EloquentJoinBuilder.php
+++ b/src/EloquentJoinBuilder.php
@@ -132,9 +132,11 @@ class EloquentJoinBuilder extends Builder
         $relationBuilder = $relation->getQuery();
 
         //apply clauses on relation
-        foreach ($relationBuilder->relationClauses as $clause) {
-            foreach ($clause as $method => $params) {
-                $this->applyClauseOnRelation($join, $method, $params, $relatedTableAlias);
+        if (isset($relationBuilder->relationClauses)) {
+            foreach ($relationBuilder->relationClauses as $clause) {
+                foreach ($clause as $method => $params) {
+                    $this->applyClauseOnRelation($join, $method, $params, $relatedTableAlias);
+                }
             }
         }
 


### PR DESCRIPTION
…ravel 5.7

I was having an issue about relationClases undefined in Laravel 5.7. I looked through some of the forks and found this: https://github.com/southcoastweb/laravel-eloquent-join/commit/36eb0e097cbb92f535e8a408ed2b062bdbacebff

This does fix my issue and seems relatively benign.