### PR TITLE
Fixed bug while joining using aliases

### DIFF
--- a/src/EloquentJoinBuilder.php
+++ b/src/EloquentJoinBuilder.php
@@ -153,7 +153,7 @@ class EloquentJoinBuilder extends Builder
             }
 
             if (!in_array($relationAccumulatedString, $this->joinedTables)) {
-                $joinQuery = $relatedTableAlias.($this->useTableAlias ? ' as '.$relatedTableAlias : '');
+                $joinQuery = $relatedTable.($this->useTableAlias ? ' as '.$relatedTableAlias : '');
                 if ($relatedRelation instanceof BelongsToJoin) {
                     $relatedKey = $relatedRelation->getQualifiedForeignKey();
                     $relatedKey = last(explode('.', $relatedKey));


### PR DESCRIPTION
It seems to be an error while joining using aliases. It joins like this:
`left join `5c5b3e39c2adf` as `5c5b3e39c2adf``

In this commit, I'm fixing it, to use actual table name in join.