### PR TITLE
Aggregate parameters are not escaped #77

### DIFF
--- a/src/EloquentJoinBuilder.php
+++ b/src/EloquentJoinBuilder.php
@@ -128,7 +128,7 @@ class EloquentJoinBuilder extends Builder
             $sortsCount = count($this->query->orders ?? []);
             $sortAlias = 'sort'.(0 == $sortsCount ? '' : ($sortsCount + 1));
 
-            $query->selectRaw($aggregateMethod.'('.$column.') as '.$sortAlias);
+            $query->selectRaw($aggregateMethod.'(?) as '.$sortAlias, [$column]);
 
             return $this->orderByRaw($sortAlias.' '.$direction);
         }


### PR DESCRIPTION
Hello,

The aggregate parameters are not escaped and if an `e` is present in the string mysql think that it is a `double` value writing in `e notation`.

Mysql error:
```
[2020-01-21 16:22:28] production.ERROR: SQLSTATE[22007]: Invalid datetime format: 1367 Illegal double '5e2725447144' value found during parsing (SQL: select preset_foo.*, MAX(5e2725447144e.code) as sort from `preset_foo` left join `bar` as `5e2725447144e` on `5e2725447144e`.`id` = `preset_foo`.`country_id` group by `preset_foo`.`id` order by sort asc limit 25 offset 0) 
[...]
```
If the aggregate is escaped it works as it should be: 
```
MAX(`5e2725447144e`.`code`)
```
