### PR TITLE
Fix #77 #78 with other solution

### DIFF
--- a/src/EloquentJoinBuilder.php
+++ b/src/EloquentJoinBuilder.php
@@ -128,7 +128,8 @@ class EloquentJoinBuilder extends Builder
             $sortsCount = count($this->query->orders ?? []);
             $sortAlias = 'sort'.(0 == $sortsCount ? '' : ($sortsCount + 1));
 
-            $query->selectRaw($aggregateMethod.'('.$column.') as '.$sortAlias);
+            $grammar = \DB::query()->getGrammar();
+            $query->selectRaw($aggregateMethod.'('.$grammar->wrap($column).') as '.$sortAlias);
 
             return $this->orderByRaw($sortAlias.' '.$direction);
         }


### PR DESCRIPTION
The solution applied in #77 that escape the column name using the build in `selectRaw` escape is not working, since the result is not really sorted.

Escape the column using `grammar` without adding a placeholder `?` in the query, do the work.