### PR TITLE
Real random table alias string (resolve #106)

### DIFF
--- a/src/EloquentJoinBuilder.php
+++ b/src/EloquentJoinBuilder.php
@@ -25,7 +25,7 @@ class EloquentJoinBuilder extends Builder
     const AGGREGATE_MIN = 'MIN';
     const AGGREGATE_COUNT = 'COUNT';
 
-    //use table alias for join (real table name or sha1)
+    //use table alias for join (real table name or random sha1)
     protected $useTableAlias = false;
 
     //appendRelationsCount
@@ -197,7 +197,7 @@ class EloquentJoinBuilder extends Builder
             $relatedModel = $relatedRelation->getRelated();
             $relatedPrimaryKey = $relatedModel->getKeyName();
             $relatedTable = $relatedModel->getTable();
-            $relatedTableAlias = $this->useTableAlias ? sha1($relatedTable) : $relatedTable;
+            $relatedTableAlias = $this->useTableAlias ? sha1($relatedTable.rand()) : $relatedTable;
 
             $relationsAccumulated[] = $relatedTableAlias;
             $relationAccumulatedString = implode('_', $relationsAccumulated);


### PR DESCRIPTION
The documentation say that with `useTableAlias` to true generate `Alias is a randomly generated string.` but doing a `sha1()` of the table name in real is not a random since with same input the result is the same, which actually is not a real difference to use an alias or the real table name.

Adding a _salt_ to the `sha1()` will generate a real random alias and resolve #106 